### PR TITLE
Setting up MongoDB for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,11 @@ jobs:
         uses: actions/setup-node@main
         with:
           node-version: '14.x'
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
+        with:
+          mongodb-version: '4.2'
           
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Added `supercharge/mongodb-github-action` in Github Actions so it starts a MongoDB database on port 27017